### PR TITLE
Update to Version 3.3.4.15443

### DIFF
--- a/.milk.yml
+++ b/.milk.yml
@@ -16,9 +16,9 @@ url: 'https://dist.mountainduck.io/Mountain%20Duck%20Installer-{{ version }}.msi
 
 searchreplace:
   'tools/chocolateyinstall.ps1':
-    - regwxp: (^\s*[$]*urlPackage\s*=\s*)('.*')
+    - regwxp: (^\s*[$]*urlPackage\s*=\s*)(".*")
       replace: '$urlPackage = "{{ url }}"'
-    - regwxp: (^\s*[$]*checksumPackage\s*=\s*)('.*')
+    - regwxp: (^\s*[$]*checksumPackage\s*=\s*)(".*")
       replace: '$checksumPackage = "{{ file_hash }}"'
 
 # readme to description

--- a/package/mountain-duck.nuspec
+++ b/package/mountain-duck.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>mountain-duck</id>
-    <version>3.3.3.15387</version>
+    <version>3.3.4.15443</version>
     <title>Mountain Duck</title>
     <authors>iterate GmbH</authors>
     <owners>sbaerlocher</owners>

--- a/package/tools/chocolateyinstall.ps1
+++ b/package/tools/chocolateyinstall.ps1
@@ -5,7 +5,7 @@ $ErrorActionPreference = 'Stop';
 $toolsDir = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
 $PackageParameters = Get-PackageParameters
 $urlPackage = "https://dist.mountainduck.io/Mountain%20Duck%20Installer-3.3.4.15443.msi"
-$checksumPackage = "5573E86948EBC4014DEC7EEED370A2D51B5ABDDEB35B36B6F8AF92397B800EB0BB6D19DA323133EB1DEB8A7C2D80BCBF84C4C0BFF7428CA7B1D4D1878377159D"
+$checksumPackage = "196B421AFDE2C450CA0ADAB902ECB62CD380C15C7BA6D912B12B0BE3AE2C549BE380334F1DD8EC88B88A041A9FDBC158EB74BB596C6FC4C9E619D8168BE72022"
 $checksumTypePackage = 'SHA512'
 
 Import-Module -Name "$($toolsDir)\helpers.ps1"

--- a/package/tools/chocolateyinstall.ps1
+++ b/package/tools/chocolateyinstall.ps1
@@ -4,8 +4,8 @@ $ErrorActionPreference = 'Stop';
 
 $toolsDir = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
 $PackageParameters = Get-PackageParameters
-$urlPackage = "https://dist.mountainduck.io/Mountain%20Duck%20Installer-3.1.2.14611.msi"
-$checksumPackage = "0b2fce1a26e639aeda8b8c44ee93c68b8e8ae036c6defa11becb48591da4f928daf143c5e22c9e2fa8979dc00f4f680d1afa4d4f28be1862844fc69964e7e8c7"
+$urlPackage = "https://dist.mountainduck.io/Mountain%20Duck%20Installer-3.3.4.15443.msi"
+$checksumPackage = "5573E86948EBC4014DEC7EEED370A2D51B5ABDDEB35B36B6F8AF92397B800EB0BB6D19DA323133EB1DEB8A7C2D80BCBF84C4C0BFF7428CA7B1D4D1878377159D"
 $checksumTypePackage = 'SHA512'
 
 Import-Module -Name "$($toolsDir)\helpers.ps1"


### PR DESCRIPTION
Chocomilk doesn't seem to properly update the chocolateyInstall.ps1 script. The URL and checksum are still pointing to version 3.1.2.14611. 

It seems like the issue is caused by the regex strings for the values in the milk.yml. The search strings contained single double quotes instead of the neutral double quotes used in the replacement string and the chocolateyInstall.ps1 script. 

I fixed the error in the milk.yml and updated the URL and checksum manually in the file chocolateyInstall.ps1. A test of the update package was successful.